### PR TITLE
Swap "aras.AlertError" for "top.aras.AlertError"

### DIFF
--- a/Import/2-Import - AddOn-Solution/My Recently Visited Items/Import/Method/RecentlyVisited AddTo UsersList.xml
+++ b/Import/2-Import - AddOn-Solution/My Recently Visited Items/Import/Method/RecentlyVisited AddTo UsersList.xml
@@ -18,7 +18,7 @@
 //alert(thisItem.dom.xml);
 	thisItem = thisItem.apply();
 	if (thisItem.isError()) {
-	  return top.aras.AlertError(thisItem.getErrorString());
+	  return aras.AlertError(thisItem.getErrorString());
 	}	
 	return;
 ]]></method_code>


### PR DESCRIPTION
The object "top.aras" is not recommended for 11 SP9. Caused a client error in this method. 

Resolves Issue #2.